### PR TITLE
Fix TypeError (PHP8) and Warning (PHP7) by casting values in the methods of ColorConverter

### DIFF
--- a/src/Color/ColorConverter.php
+++ b/src/Color/ColorConverter.php
@@ -206,12 +206,12 @@ class ColorConverter
 		$g = hexdec(substr($cor, 3, 2));
 		$b = hexdec(substr($cor, 5, 2));
 
-        return [
-            3,
-            (float) $r,
-            (float) $g,
-            (float) $b
-        ];
+		return [
+			3,
+			(float) $r,
+			(float) $g,
+			(float) $b
+		];
 	}
 
 	/**

--- a/src/Color/ColorConverter.php
+++ b/src/Color/ColorConverter.php
@@ -173,7 +173,7 @@ class ColorConverter
 		$c = false;
 
 		if (preg_match('/^[\d]+$/', $color)) {
-			$c = [static::MODE_GRAYSCALE, $color]; // i.e. integer only
+			$c = [static::MODE_GRAYSCALE, (float) $color]; // i.e. integer only
 		} elseif (strpos($color, '#') === 0) { // case of #nnnnnn or #nnn
 			$c = $this->processHashColor($color);
 		} elseif (preg_match('/(rgba|rgb|device-cmyka|cmyka|device-cmyk|cmyk|hsla|hsl|spot)\((.*?)\)/', $color, $m)) {
@@ -206,7 +206,12 @@ class ColorConverter
 		$g = hexdec(substr($cor, 3, 2));
 		$b = hexdec(substr($cor, 5, 2));
 
-		return [3, $r, $g, $b];
+        return [
+            3,
+            (float) $r,
+            (float) $g,
+            (float) $b
+        ];
 	}
 
 	/**
@@ -222,25 +227,25 @@ class ColorConverter
 
 		switch ($mode) {
 			case 'rgb':
-				return [static::MODE_RGB, $cores[0], $cores[1], $cores[2]];
+				return [static::MODE_RGB, (float) $cores[0], (float) $cores[1], (float) $cores[2]];
 
 			case 'rgba':
-				return [static::MODE_RGBA, $cores[0], $cores[1], $cores[2], $cores[3] * 100];
+				return [static::MODE_RGBA, (float) $cores[0], (float) $cores[1], (float) $cores[2], $cores[3] * 100];
 
 			case 'cmyk':
 			case 'device-cmyk':
-				return [static::MODE_CMYK, $cores[0], $cores[1], $cores[2], $cores[3]];
+				return [static::MODE_CMYK, (float) $cores[0], (float) $cores[1], (float) $cores[2], (float) $cores[3]];
 
 			case 'cmyka':
 			case 'device-cmyka':
-				return [static::MODE_CMYKA, $cores[0], $cores[1], $cores[2], $cores[3], $cores[4] * 100];
+				return [static::MODE_CMYKA, (float) $cores[0], (float) $cores[1], (float) $cores[2], (float) $cores[3], $cores[4] * 100];
 
 			case 'hsl':
-				$conv = $this->colorModeConverter->hsl2rgb($cores[0] / 360, $cores[1], $cores[2]);
+				$conv = $this->colorModeConverter->hsl2rgb($cores[0] / 360, (float) $cores[1], (float) $cores[2]);
 				return [static::MODE_RGB, $conv[0], $conv[1], $conv[2]];
 
 			case 'hsla':
-				$conv = $this->colorModeConverter->hsl2rgb($cores[0] / 360, $cores[1], $cores[2]);
+				$conv = $this->colorModeConverter->hsl2rgb($cores[0] / 360, (float) $cores[1], (float) $cores[2]);
 				return [static::MODE_RGBA, $conv[0], $conv[1], $conv[2], $cores[3] * 100];
 
 			case 'spot':
@@ -248,13 +253,13 @@ class ColorConverter
 
 				if (!isset($this->mpdf->spotColors[$name])) {
 					if (isset($cores[5])) {
-						$this->mpdf->AddSpotColor($cores[0], $cores[2], $cores[3], $cores[4], $cores[5]);
+						$this->mpdf->AddSpotColor((float) $cores[0], (float) $cores[2], (float) $cores[3], (float) $cores[4], (float) $cores[5]);
 					} else {
 						throw new \Mpdf\MpdfException(sprintf('Undefined spot color "%s"', $name));
 					}
 				}
 
-				return [static::MODE_SPOT, $this->mpdf->spotColors[$name]['i'], $cores[1]];
+				return [static::MODE_SPOT, $this->mpdf->spotColors[$name]['i'], (float) $cores[1]];
 		}
 
 		return $c;

--- a/tests/Mpdf/Color/ColorConverterTest.php
+++ b/tests/Mpdf/Color/ColorConverterTest.php
@@ -89,6 +89,8 @@ class ColorConverterTest extends \PHPUnit_Framework_TestCase
 			['inherit', false],
 			['transparent', false],
 
+            ['#CCC url("img_tree.gif")', "3\xcc\xcc\xcc\x00\x00"],
+            ['rgba(var(--sk_highlight,18,100,163),1)', "5\x00\x12d\xac\x00"],
 		];
 	}
 

--- a/tests/Mpdf/Color/ColorConverterTest.php
+++ b/tests/Mpdf/Color/ColorConverterTest.php
@@ -89,8 +89,8 @@ class ColorConverterTest extends \PHPUnit_Framework_TestCase
 			['inherit', false],
 			['transparent', false],
 
-            ['#CCC url("img_tree.gif")', "3\xcc\xcc\xcc\x00\x00"],
-            ['rgba(var(--sk_highlight,18,100,163),1)', "5\x00\x12d\xac\x00"],
+			['#CCC url("img_tree.gif")', "3\xcc\xcc\xcc\x00\x00"],
+			['rgba(var(--sk_highlight,18,100,163),1)', "5\x00\x12d\xac\x00"],
 		];
 	}
 


### PR DESCRIPTION

In PHP8 a type error will be thrown if the array, which is passed to the pack-Method in ColorConverter:convert, contains something other than a float or int. This is behaviour is currently the case as the type hint in the doc block is not honored and the array may contain a string. 

This is the case for something like: 

`'rgba(var(--sk_highlight,18,100,163),1)'`

The convert method under PHP7 will throw the following warning: 

> Warning: A non-numeric value encountered 

In PHP8 the following error will be thrown:

>  Uncaught TypeError: Unsupported operand types

A simplified example of this behaviour can be found here:

https://3v4l.org/hZU29

The produced array for the aforementioned example by the method ColorConverter:convertPlain 
is this:

<img width="433" alt="Screenshot 2021-04-22 at 12 01 47" src="https://user-images.githubusercontent.com/19969518/115832034-afc19c80-a412-11eb-84e9-232eb9bcefd7.png">

In the linked example we see that the value gets interpreted as int(0)

I've added some test cases to reflect on the changes-.

However the changes doesn't adhere to the typehint in the doc block due to the fact that the color mode 
is included in the array and a casting of this value to float may introduce unexpected behaviour.